### PR TITLE
chore: rename org from airconduct to aionops

### DIFF
--- a/examples/github/example_test.go
+++ b/examples/github/example_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 
-	"github.com/airconduct/go-probot"
-	"github.com/airconduct/go-probot/mock"
+	"github.com/aionops/go-probot"
+	"github.com/aionops/go-probot/mock"
 )
 
 var _ = Describe("Test Probot Example", func() {

--- a/examples/github/main.go
+++ b/examples/github/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-github/v48/github"
 	"github.com/spf13/pflag"
 
-	"github.com/airconduct/go-probot"
+	"github.com/aionops/go-probot"
 )
 
 func main() {

--- a/github_app.go
+++ b/github_app.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/oauth2"
 
-	"github.com/airconduct/go-probot/web"
+	"github.com/aionops/go-probot/web"
 )
 
 func NewGitHubAPP() App[GitHubClient] {

--- a/github_app_test.go
+++ b/github_app_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 
-	"github.com/airconduct/go-probot"
-	"github.com/airconduct/go-probot/mock"
+	"github.com/aionops/go-probot"
+	"github.com/aionops/go-probot/mock"
 )
 
 func TestGitHubAPP(t *testing.T) {

--- a/github_events_test.go
+++ b/github_events_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/airconduct/go-probot"
+	"github.com/aionops/go-probot"
 	"github.com/google/go-github/v48/github"
 )
 

--- a/github_events_test.go.tmpl
+++ b/github_events_test.go.tmpl
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/airconduct/go-probot"
+	"github.com/aionops/go-probot"
 	"github.com/google/go-github/v48/github"
 )
 

--- a/gitlab_app_test.go
+++ b/gitlab_app_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/airconduct/go-probot"
-	"github.com/airconduct/go-probot/mock"
+	"github.com/aionops/go-probot"
+	"github.com/aionops/go-probot/mock"
 )
 
 func TestGitLabApp(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/airconduct/go-probot
+module github.com/aionops/go-probot
 
 go 1.26
 

--- a/metrics.go
+++ b/metrics.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/airconduct/go-probot/web/backend"
+	"github.com/aionops/go-probot/web/backend"
 )
 
 type eventMetrics struct {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/h2non/gock"
 
-	"github.com/airconduct/go-probot"
+	"github.com/aionops/go-probot"
 )
 
 type AppMock[GT probot.GitClientType] interface {

--- a/web/simple/main.go
+++ b/web/simple/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/airconduct/go-probot/web"
-	"github.com/airconduct/go-probot/web/backend"
+	"github.com/aionops/go-probot/web"
+	"github.com/aionops/go-probot/web/backend"
 )
 
 func main() {

--- a/web/web.go
+++ b/web/web.go
@@ -9,7 +9,7 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"github.com/go-openapi/spec"
 
-	"github.com/airconduct/go-probot/web/backend"
+	"github.com/aionops/go-probot/web/backend"
 )
 
 //go:embed dist/*

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/airconduct/go-probot/web"
-	"github.com/airconduct/go-probot/web/backend"
+	"github.com/aionops/go-probot/web"
+	"github.com/aionops/go-probot/web/backend"
 )
 
 var _ = Describe("Web", func() {


### PR DESCRIPTION
## Summary
- Rename all import paths from `github.com/airconduct/go-probot` to `github.com/aionops/go-probot`
- 13 files updated across Go sources, templates, and go.mod

## Test plan
- [x] `go build ./...` passes
- [ ] `make test` passes

🤖 Generated with [Deepseek](https://deepseek.com)